### PR TITLE
Small fixes for circular download status badges

### DIFF
--- a/Steamdeck/ShowDownloadStatus/varients/circle.css
+++ b/Steamdeck/ShowDownloadStatus/varients/circle.css
@@ -55,9 +55,7 @@
 .appportrait_InCollection_3ANru.gpfocuswithin:only-child::before,
 .appportrait_InRecentGames_biTV-:hover:only-child::before,
 .appportrait_InCollection_3ANru:hover:only-child::before,
-.appportrait_InRecentGames_biTV-.gpfocuswithin .appportrait_UninstalledIcon_8YrRm,
-.appportrait_InCollection_3ANru.gpfocuswithin .appportrait_UninstalledIcon_8YrRm,
-.appportrait_InRecentGames_biTV-:hover .appportrait_UninstalledIcon_8YrRm,
-.appportrait_InCollection_3ANru:hover .appportrait_UninstalledIcon_8YrRm {
-  opacity: 1 !important;
+.appportrait_HoversEnabled_54PuC .appportrait_LibraryItemBox_WYgDg:hover .appportrait_UninstalledIcon_8YrRm,
+.appportrait_LibraryItemBox_WYgDg.gpfocus .appportrait_UninstalledIcon_8YrRm {
+  opacity: 1;
 }

--- a/Steamdeck/ShowDownloadStatus/varients/circle.css
+++ b/Steamdeck/ShowDownloadStatus/varients/circle.css
@@ -51,11 +51,9 @@
   transition: all .1s cubic-bezier(0.16, 0.86, 0.43, 0.99);
 }
 
-.appportrait_InRecentGames_biTV-.gpfocuswithin:only-child::before,
-.appportrait_InCollection_3ANru.gpfocuswithin:only-child::before,
-.appportrait_InRecentGames_biTV-:hover:only-child::before,
-.appportrait_InCollection_3ANru:hover:only-child::before,
-.appportrait_HoversEnabled_54PuC .appportrait_LibraryItemBox_WYgDg:hover .appportrait_UninstalledIcon_8YrRm,
-.appportrait_LibraryItemBox_WYgDg.gpfocus .appportrait_UninstalledIcon_8YrRm {
+.appportrait_LibraryItemBox_WYgDg.Focusable:focus:only-child::before,
+.appportrait_LibraryItemBox_WYgDg:hover:only-child::before,
+.appportrait_LibraryItemBox_WYgDg.Focusable:focus .appportrait_UninstalledIcon_8YrRm,
+.appportrait_HoversEnabled_54PuC .appportrait_LibraryItemBox_WYgDg:hover .appportrait_UninstalledIcon_8YrRm {
   opacity: 1;
 }

--- a/Steamdeck/ShowDownloadStatus/varients/circleNoUninstall.css
+++ b/Steamdeck/ShowDownloadStatus/varients/circleNoUninstall.css
@@ -33,3 +33,7 @@
 .appportrait_InCollection_3ANru:hover:only-child::before  {
   opacity: 1;
 }
+
+.BasicUI .appportrait_LibraryItemBox_WYgDg .appportrait_UninstalledIcon_8YrRm {
+  display: none;
+}

--- a/Steamdeck/ShowDownloadStatus/varients/circleNoUninstall.css
+++ b/Steamdeck/ShowDownloadStatus/varients/circleNoUninstall.css
@@ -27,10 +27,8 @@
   left: 1.5%;
 }
 
-.appportrait_InRecentGames_biTV-.gpfocuswithin:only-child::before,
-.appportrait_InCollection_3ANru.gpfocuswithin:only-child::before,
-.appportrait_InRecentGames_biTV-:hover:only-child::before,
-.appportrait_InCollection_3ANru:hover:only-child::before  {
+.appportrait_LibraryItemBox_WYgDg.Focusable:focus:only-child::before,
+.appportrait_LibraryItemBox_WYgDg:hover:only-child::before {
   opacity: 1;
 }
 


### PR DESCRIPTION
hi again, @Tormak9970 😅

I noticed that I've used `!important` rule while changing opacity of the download status icons, this was causing opacity animations to be ignored. also, uninstalled icon was still showing up when you hover over the icon itself with mouse for the no uninstalled variant.