### PR TITLE
Fix uninstalled icon display issue for no uninstall variant

### DIFF
--- a/Steamdeck/ShowDownloadStatus/varients/circleNoUninstall.css
+++ b/Steamdeck/ShowDownloadStatus/varients/circleNoUninstall.css
@@ -33,3 +33,7 @@
 .appportrait_InCollection_3ANru:hover:only-child::before  {
   opacity: 1;
 }
+
+.BasicUI .appportrait_LibraryItemBox_WYgDg .appportrait_UninstalledIcon_8YrRm {
+  display: none; /* uninstalled icon is appearing when hovered with mouse without this */
+}


### PR DESCRIPTION
For "show install status" theme's "circular (no uninstall)" variant, I've noticed that no uninstall icon appears when it's hovered over with mouse, a small fix to address that.